### PR TITLE
Mark SwiftRecord applicationWillTerminate with @objc.

### DIFF
--- a/Classes/SwiftRecord.swift
+++ b/Classes/SwiftRecord.swift
@@ -171,7 +171,7 @@ public class SwiftRecord {
         NSNotificationCenter.defaultCenter().addObserver(self, selector: "applicationWillTerminate", name: UIApplicationWillTerminateNotification, object: nil)
         #endif
     }
-    public func applicationWillTerminate() {
+    @objc public func applicationWillTerminate() {
     #if os(iOS)
         NSNotificationCenter.defaultCenter().removeObserver(self)
         saveContext()


### PR DESCRIPTION
This will prevent a crash as the observer can't find the selector otherwise.