### PR TITLE
Converted code base to Swift 3.0.

### DIFF
--- a/Classes/SwiftRecord.swift
+++ b/Classes/SwiftRecord.swift
@@ -12,19 +12,19 @@ import CoreData
 import UIKit
 #endif
 
-public class SwiftRecord {
+open class SwiftRecord {
     
-    public static var generateRelationships = false
+    open static var generateRelationships = false
     
-    public static func setUpEntities(entities: [String:NSManagedObject.Type]) {
+    open static func setUpEntities(_ entities: [String:NSManagedObject.Type]) {
         nameToEntities = entities
     }
     
-    private static var nameToEntities: [String:NSManagedObject.Type] = [String:NSManagedObject.Type]()
+    fileprivate static var nameToEntities: [String:NSManagedObject.Type] = [String:NSManagedObject.Type]()
     
-    public let appName = NSBundle.mainBundle().infoDictionary!["CFBundleName"] as! String
+    open let appName = Bundle.main.infoDictionary!["CFBundleName"] as! String
     
-    public var databaseName: String {
+    open var databaseName: String {
         get {
             if let db = self._databaseName {
                 return db
@@ -42,9 +42,9 @@ public class SwiftRecord {
             }
         }
     }
-    private var _databaseName: String?
+    fileprivate var _databaseName: String?
     
-    public var modelName: String {
+    open var modelName: String {
         get {
             if let model = _modelName {
                 return model
@@ -62,14 +62,14 @@ public class SwiftRecord {
             }
         }
     }
-    private var _modelName: String?
+    fileprivate var _modelName: String?
     
-    public var managedObjectContext: NSManagedObjectContext {
+    open var managedObjectContext: NSManagedObjectContext {
         get {
             if let context = _managedObjectContext {
                 return context
             } else {
-                let c = NSManagedObjectContext(concurrencyType: NSManagedObjectContextConcurrencyType.MainQueueConcurrencyType)
+                let c = NSManagedObjectContext(concurrencyType: NSManagedObjectContextConcurrencyType.mainQueueConcurrencyType)
                 c.persistentStoreCoordinator = persistentStoreCoordinator
                 _managedObjectContext = c
                 return c
@@ -79,9 +79,9 @@ public class SwiftRecord {
             _managedObjectContext = newValue
         }
     }
-    private var _managedObjectContext: NSManagedObjectContext?
+    fileprivate var _managedObjectContext: NSManagedObjectContext?
     
-    public var persistentStoreCoordinator: NSPersistentStoreCoordinator {
+    open var persistentStoreCoordinator: NSPersistentStoreCoordinator {
         if let store = _persistentStoreCoordinator {
             return store
         } else {
@@ -90,15 +90,15 @@ public class SwiftRecord {
             return p
         }
     }
-    private var _persistentStoreCoordinator: NSPersistentStoreCoordinator?
+    fileprivate var _persistentStoreCoordinator: NSPersistentStoreCoordinator?
     
-    public var managedObjectModel: NSManagedObjectModel {
+    open var managedObjectModel: NSManagedObjectModel {
         get {
             if let m = _managedObjectModel {
                 return m
             } else {
-                let modelURL = NSBundle.mainBundle().URLForResource(self.modelName, withExtension: "momd")
-                _managedObjectModel = NSManagedObjectModel(contentsOfURL: modelURL!)
+                let modelURL = Bundle.main.url(forResource: self.modelName, withExtension: "momd")
+                _managedObjectModel = NSManagedObjectModel(contentsOf: modelURL!)
                 return _managedObjectModel!
             }
         }
@@ -106,13 +106,13 @@ public class SwiftRecord {
             _managedObjectModel = newValue
         }
     }
-    private var _managedObjectModel: NSManagedObjectModel?
+    fileprivate var _managedObjectModel: NSManagedObjectModel?
     
-    public func useInMemoryStore() {
+    open func useInMemoryStore() {
         _persistentStoreCoordinator = self.persistentStoreCoordinator(NSInMemoryStoreType, storeURL: nil)
     }
     
-    public func saveContext() -> Bool {
+    open func saveContext() -> Bool {
         if !self.managedObjectContext.hasChanges {
             return false
         }
@@ -127,58 +127,58 @@ public class SwiftRecord {
         return true
     }
     
-    public func applicationDocumentsDirectory() -> NSURL {
-        return NSFileManager.defaultManager().URLsForDirectory(NSSearchPathDirectory.DocumentDirectory, inDomains: NSSearchPathDomainMask.UserDomainMask).last!
+    open func applicationDocumentsDirectory() -> URL {
+        return FileManager.default.urls(for: FileManager.SearchPathDirectory.documentDirectory, in: FileManager.SearchPathDomainMask.userDomainMask).last!
     }
     
-    public func applicationSupportDirectory() -> NSURL {
-        return (NSFileManager.defaultManager().URLsForDirectory(NSSearchPathDirectory.ApplicationSupportDirectory, inDomains: NSSearchPathDomainMask.UserDomainMask).last!).URLByAppendingPathComponent(self.appName)!
+    open func applicationSupportDirectory() -> URL {
+        return (FileManager.default.urls(for: FileManager.SearchPathDirectory.applicationSupportDirectory, in: FileManager.SearchPathDomainMask.userDomainMask).last!).appendingPathComponent(self.appName)
     }
     
-    public var sqliteStoreURL: NSURL {
+    open var sqliteStoreURL: URL {
         #if os(iOS)
             let dir = self.applicationDocumentsDirectory()
         #else
             let dir = self.applicationSupportDirectory()
             self.createApplicationSupportDirIfNeeded(dir)
         #endif
-        return dir.URLByAppendingPathComponent(self.databaseName)!
+        return dir.appendingPathComponent(self.databaseName)
         
     }
     
-    private func persistentStoreCoordinator(storeType: String, storeURL: NSURL?) -> NSPersistentStoreCoordinator {
+    fileprivate func persistentStoreCoordinator(_ storeType: String, storeURL: URL?) -> NSPersistentStoreCoordinator {
         let c = NSPersistentStoreCoordinator(managedObjectModel: self.managedObjectModel)
         do {
-            try c.addPersistentStoreWithType(storeType, configuration: nil, URL: storeURL, options: [NSMigratePersistentStoresAutomaticallyOption:true, NSInferMappingModelAutomaticallyOption:true])
+            try c.addPersistentStore(ofType: storeType, configurationName: nil, at: storeURL, options: [NSMigratePersistentStoresAutomaticallyOption:true, NSInferMappingModelAutomaticallyOption:true])
         } catch let error as NSError {
             print("ERROR WHILE CREATING PERSISTENT STORE COORDINATOR! " + error.debugDescription)
         }
         return c
     }
     
-    private func createApplicationSupportDirIfNeeded(dir: NSURL) {
-        if NSFileManager.defaultManager().fileExistsAtPath(dir.absoluteString!) {
+    fileprivate func createApplicationSupportDirIfNeeded(_ dir: URL) {
+        if FileManager.default.fileExists(atPath: dir.absoluteString) {
             return
         }
         do {
-            try NSFileManager.defaultManager().createDirectoryAtURL(dir, withIntermediateDirectories: true, attributes: nil)
+            try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true, attributes: nil)
         } catch let error as NSError {
             print("ERROR WHILE CREATING APPLICATION SUPPORT DIRECTORY! " + error.debugDescription)
         }
     }
-    private init() {
+    fileprivate init() {
         #if os(iOS)
-        NSNotificationCenter.defaultCenter().addObserver(self, selector: #selector(SwiftRecord.applicationWillTerminate), name: UIApplicationWillTerminateNotification, object: nil)
+        NotificationCenter.default.addObserver(self, selector: #selector(SwiftRecord.applicationWillTerminate), name: NSNotification.Name.UIApplicationWillTerminate, object: nil)
         #endif
     }
-    @objc public func applicationWillTerminate() {
+    @objc open func applicationWillTerminate() {
     #if os(iOS)
-        NSNotificationCenter.defaultCenter().removeObserver(self)
-        saveContext()
+        NotificationCenter.default.removeObserver(self)
+        _ = saveContext()
     #endif
     }
     // singleton
-    public static let sharedRecord = SwiftRecord()
+    open static let sharedRecord = SwiftRecord()
 }
 
 public extension NSManagedObjectContext {
@@ -187,116 +187,177 @@ public extension NSManagedObjectContext {
     }
 }
 
-public extension NSManagedObject {
+extension NSManagedObject {
     
     //Querying
-    
-    public static func all() -> [NSManagedObject] {
-        return self.all(context: NSManagedObjectContext.defaultContext)
+    @nonobjc public static func all(context: NSManagedObjectContext = NSManagedObjectContext.defaultContext) -> [NSManagedObject] {
+        return self.fetch(predicate: nil, context: context, sortQuery: nil, limit: nil)
+    }
+
+    @nonobjc public static func all(context: NSManagedObjectContext = NSManagedObjectContext.defaultContext, sort: String?) -> [NSManagedObject] {
+        return self.fetch(predicate: nil, context: context, sortQuery: sort, limit: nil)
+    }
+
+    @nonobjc public static func all(context: NSManagedObjectContext = NSManagedObjectContext.defaultContext, sort: [[String: Any]]?) -> [NSManagedObject] {
+        return self.fetch(predicate: nil, context: context, sortConditions: sort, limit: nil)
     }
     
-    public static func all(sort sort: AnyObject) -> [NSManagedObject] {
-        return self.all(context: NSManagedObjectContext.defaultContext, withSort:sort)
-    }
-    
-    public static func all(context context: NSManagedObjectContext) -> [NSManagedObject] {
-        return self.all(context: context, withSort: nil)
-    }
-    
-    public static func all(context context: NSManagedObjectContext, withSort sort: AnyObject?) -> [NSManagedObject] {
-        return self.fetch(nil, context: context, sort: sort, limit: nil)
-    }
-    
-    public static func findOrCreate(properties: [String:AnyObject]) -> NSManagedObject {
+    @nonobjc public static func findOrCreate(_ properties: [String: Any]) -> NSManagedObject {
         return self.findOrCreate(properties, context: NSManagedObjectContext.defaultContext)
     }
     
-    public static func findOrCreate(properties: [String:AnyObject], context: NSManagedObjectContext) -> NSManagedObject {
+    @nonobjc public static func findOrCreate(_ properties: [String: Any], context: NSManagedObjectContext) -> NSManagedObject {
         let transformed = self.transformProperties(properties, context: context)
         let existing: NSManagedObject? = self.query(transformed, context: context).first
         return existing ?? self.create(transformed, context:context)
     }
-    
-    public static func find(condition: AnyObject, args: AnyObject...) -> NSManagedObject? {
-        let predicate: NSPredicate = self.predicate(condition, args: args);
-        return self.find(predicate, context: NSManagedObjectContext.defaultContext)
+
+    @nonobjc public static func find(_ condition: String, context: NSManagedObjectContext = NSManagedObjectContext.defaultContext, argsArray: [Any]? = nil) -> NSManagedObject? {
+        return self.query(condition, context: context, limit: 1, argsArray: argsArray).first
+    }
+
+    @nonobjc public static func find(_ condition: String, context: NSManagedObjectContext = NSManagedObjectContext.defaultContext, args: Any...) -> NSManagedObject? {
+        return self.query(condition, context: context, limit: 1, argsArray: args).first
+    }
+
+    @nonobjc public static func find(_ condition: String, context: NSManagedObjectContext = NSManagedObjectContext.defaultContext, sort: String?, argsArray: [Any]? = nil) -> NSManagedObject? {
+        return self.query(condition, context: context, sort: sort, limit: 1, argsArray: argsArray).first
+    }
+
+    @nonobjc public static func find(_ condition: String, context: NSManagedObjectContext = NSManagedObjectContext.defaultContext, sort: String?, args: Any...) -> NSManagedObject? {
+        return self.query(condition, context: context, sort: sort, limit: 1, argsArray: args).first
+    }
+
+    @nonobjc public static func find(_ condition: String, context: NSManagedObjectContext = NSManagedObjectContext.defaultContext, sort: [[String: Any]]?, argsArray: [Any]? = nil) -> NSManagedObject? {
+        return self.query(condition, context: context, sort: sort, limit: 1, argsArray: argsArray).first
+    }
+
+    @nonobjc public static func find(_ condition: String, context: NSManagedObjectContext = NSManagedObjectContext.defaultContext, sort: [[String: Any]]?, args: Any...) -> NSManagedObject? {
+        return self.query(condition, context: context, sort: sort, limit: 1, argsArray: args).first
+    }
+
+    @nonobjc public static func find(_ condition: [String: Any], context: NSManagedObjectContext = NSManagedObjectContext.defaultContext, sort: String?) -> NSManagedObject? {
+        return self.query(condition, context: context, sort: sort, limit: 1).first
+    }
+
+    @nonobjc public static func find(_ condition: [String: Any], context: NSManagedObjectContext = NSManagedObjectContext.defaultContext, sort: [[String: Any]]?) -> NSManagedObject? {
+        return self.query(condition, context: context, sort: sort, limit: 1).first
+    }
+
+    @nonobjc public static func find(_ condition: NSPredicate, context: NSManagedObjectContext = NSManagedObjectContext.defaultContext, sort: String?) -> NSManagedObject? {
+        return self.query(condition, context: context, sort: sort, limit: 1).first
+    }
+
+    @nonobjc public static func find(_ condition: NSPredicate, context: NSManagedObjectContext = NSManagedObjectContext.defaultContext, sort: [[String: Any]]?) -> NSManagedObject? {
+        return self.query(condition, context: context, sort: sort, limit: 1).first
+    }
+
+    @nonobjc public static func query(_ condition: String, context: NSManagedObjectContext = NSManagedObjectContext.defaultContext, limit: Int? = nil, argsArray: [Any]? = nil) -> [NSManagedObject] {
+        return self.fetch(query: condition, context: context, sortDescriptors: nil, limit: limit, args: argsArray)
+    }
+
+    @nonobjc public static func query(_ condition: String, context: NSManagedObjectContext = NSManagedObjectContext.defaultContext, limit: Int? = nil, args: Any...) -> [NSManagedObject] {
+        return self.fetch(query: condition, context: context, sortDescriptors: nil, limit: limit, args: args)
     }
     
-    public static func find(condition: AnyObject, context: NSManagedObjectContext) -> NSManagedObject? {
-        return self.query(condition, context: context, sort:nil, limit:1).first
+    @nonobjc public static func query(_ condition: String, context: NSManagedObjectContext = NSManagedObjectContext.defaultContext, sort: String?, limit: Int? = nil, argsArray: [Any]? = nil) -> [NSManagedObject] {
+        return self.fetch(query: condition, context: context, sortQuery: sort, limit: limit, args: argsArray)
     }
-    
-    public static func query(condition: AnyObject, args: AnyObject...) -> [NSManagedObject] {
-        let predicate: NSPredicate = self.predicate(condition, args: args)
-        return self.query(predicate, context:NSManagedObjectContext.defaultContext)
+
+    @nonobjc public static func query(_ condition: String, context: NSManagedObjectContext = NSManagedObjectContext.defaultContext, sort: String?, limit: Int? = nil, args: Any...) -> [NSManagedObject] {
+        return self.fetch(query: condition, context: context, sortQuery: sort, limit: limit, args: args)
     }
-    
-    public static func query(condition: AnyObject, sort: AnyObject) -> [NSManagedObject] {
-        return self.query(condition, context: NSManagedObjectContext.defaultContext, sort: sort)
+
+    @nonobjc public static func query(_ condition: String, context: NSManagedObjectContext = NSManagedObjectContext.defaultContext, sort: [[String: Any]]?, limit: Int? = nil, argsArray: [Any]? = nil) -> [NSManagedObject] {
+        return self.fetch(query: condition, context: context, sortConditions: sort, limit: limit, args: argsArray)
     }
-    
-    public static func query(condition: AnyObject, limit: Int) -> [NSManagedObject] {
-        return self.query(condition, context: NSManagedObjectContext.defaultContext, sort:nil, limit: limit)
+
+    @nonobjc public static func query(_ condition: String, context: NSManagedObjectContext = NSManagedObjectContext.defaultContext, sort: [[String: Any]]?, limit: Int? = nil, args: Any...) -> [NSManagedObject] {
+        return self.fetch(query: condition, context: context, sortConditions: sort, limit: limit, args: args)
     }
-    
-    public static func query(condition: AnyObject, sort: AnyObject, limit: Int) -> [NSManagedObject] {
-        return self.query(condition, context: NSManagedObjectContext.defaultContext, sort: sort, limit: limit)
+
+    @nonobjc public static func query(_ condition: String, context: NSManagedObjectContext = NSManagedObjectContext.defaultContext, sort: [String: Any]?, limit: Int? = nil, argsArray: [Any]? = nil) -> [NSManagedObject] {
+        return self.fetch(query: condition, context: context, sortCondition: sort, limit: limit, args: argsArray)
     }
-    
-    public static func query(condition: AnyObject, context: NSManagedObjectContext) -> [NSManagedObject] {
-        return self.query(condition, context: context, sort: nil, limit: nil)
+
+    @nonobjc public static func query(_ condition: String, context: NSManagedObjectContext = NSManagedObjectContext.defaultContext, sort: [String: Any]?, limit: Int? = nil, args: Any...) -> [NSManagedObject] {
+        return self.fetch(query: condition, context: context, sortCondition: sort, limit: limit, args: args)
     }
-    
-    public static func query(condition: AnyObject, context: NSManagedObjectContext, sort: AnyObject) -> [NSManagedObject] {
-        return self.query(condition, context: context, sort: sort, limit: nil)
+
+    @nonobjc public static func query(_ condition: [String: Any], context: NSManagedObjectContext = NSManagedObjectContext.defaultContext, limit: Int? = nil) -> [NSManagedObject] {
+        return self.fetch(properties: condition, context: context, sortDescriptors: nil, limit: limit)
     }
-    
-    public static func query(condition: AnyObject, context: NSManagedObjectContext, sort: AnyObject?, limit: Int?) -> [NSManagedObject] {
-        return self.fetch(condition, context: context, sort: sort, limit: limit)
+
+    @nonobjc public static func query(_ condition: [String: Any], context: NSManagedObjectContext = NSManagedObjectContext.defaultContext, sort: String?, limit: Int? = nil) -> [NSManagedObject] {
+        return self.fetch(properties: condition, context: context, sortQuery: sort, limit: limit)
+    }
+
+    @nonobjc public static func query(_ condition: [String: Any], context: NSManagedObjectContext = NSManagedObjectContext.defaultContext, sort: [[String: Any]]?, limit: Int? = nil) -> [NSManagedObject] {
+        return self.fetch(properties: condition, context: context, sortConditions: sort, limit: limit)
+    }
+
+    @nonobjc public static func query(_ condition: [String: Any], context: NSManagedObjectContext = NSManagedObjectContext.defaultContext, sort: [String: Any]?, limit: Int? = nil) -> [NSManagedObject] {
+        return self.fetch(properties: condition, context: context, sortCondition: sort, limit: limit)
+    }
+
+    @nonobjc public static func query(_ condition: NSPredicate, context: NSManagedObjectContext = NSManagedObjectContext.defaultContext, limit: Int? = nil) -> [NSManagedObject] {
+        return self.fetch(predicate: condition, context: context, sortDescriptors: nil, limit: limit)
+    }
+
+    @nonobjc public static func query(_ condition: NSPredicate, context: NSManagedObjectContext = NSManagedObjectContext.defaultContext, sort: [[String: Any]]?, limit: Int? = nil) -> [NSManagedObject] {
+        return self.fetch(predicate: condition, context: context, sortConditions: sort, limit: limit)
+    }
+
+    @nonobjc public static func query(_ condition: NSPredicate, context: NSManagedObjectContext = NSManagedObjectContext.defaultContext, sort: [String: Any]?, limit: Int? = nil) -> [NSManagedObject] {
+        return self.fetch(predicate: condition, context: context, sortCondition: sort, limit: limit)
+    }
+
+    @nonobjc public static func query(_ condition: NSPredicate, context: NSManagedObjectContext = NSManagedObjectContext.defaultContext, sort: String?, limit: Int? = nil) -> [NSManagedObject] {
+        return self.fetch(predicate: condition, context: context, sortQuery: sort, limit: limit)
     }
     
     // Aggregation
-    
-    public static func count() -> Int {
-        return self.count(NSManagedObjectContext.defaultContext)
-    }
-    
-    public static func count(query query: AnyObject, args: AnyObject...) -> Int {
-        let predicate = self.predicate(query, args: args)
-        return self.count(query: predicate, context:NSManagedObjectContext.defaultContext)
-    }
-    
-    public static func count(context: NSManagedObjectContext) -> Int {
+    @nonobjc public static func count(_ context: NSManagedObjectContext = NSManagedObjectContext.defaultContext) -> Int {
         return self.countForFetch(nil, context: context)
     }
-    
-    public static func count(query query: AnyObject, context: NSManagedObjectContext) -> Int {
-        return self.countForFetch(self.predicate(query), context: context)
+
+    @nonobjc public static func count(query: [String: Any], context: NSManagedObjectContext = NSManagedObjectContext.defaultContext) -> Int {
+        let predicate = self.predicate(query)
+        return self.countForFetch(predicate, context: context)
+    }
+
+    @nonobjc public static func count(query: String, context: NSManagedObjectContext = NSManagedObjectContext.defaultContext, args: Any...) -> Int {
+        let predicate = self.predicate(query, args: args)
+        return self.countForFetch(predicate, context: context)
+    }
+
+    @nonobjc public static func count(query: NSPredicate, context: NSManagedObjectContext = NSManagedObjectContext.defaultContext) -> Int {
+        return self.countForFetch(query, context: context)
     }
     
     // Creation / Deletion
-    public static func create() -> NSManagedObject {
+    @nonobjc public static func create() -> NSManagedObject {
         return self.create(context: NSManagedObjectContext.defaultContext)
     }
     
-    public static func create(context context: NSManagedObjectContext) -> NSManagedObject {
-        let o = NSEntityDescription.insertNewObjectForEntityForName(self.entityName(), inManagedObjectContext: context) as NSManagedObject
+    @nonobjc public static func create(context: NSManagedObjectContext) -> NSManagedObject {
+        let o = NSEntityDescription.insertNewObject(forEntityName: self.entityName(), into: context) as NSManagedObject
         if let idprop = self.autoIncrementingId() {
-            o.setPrimitiveValue(NSNumber(integer: self.nextId()), forKey: idprop)
+            o.setPrimitiveValue(NSNumber(value: self.nextId() as Int), forKey: idprop)
         }
         return o
     }
     
-    public static func create(properties properties: [String:AnyObject]) -> NSManagedObject {
+    @nonobjc public static func create(properties: [String: Any]) -> NSManagedObject {
         return self.create(properties, context: NSManagedObjectContext.defaultContext)
     }
     
-    public static func create(properties: [String:AnyObject], context: NSManagedObjectContext) -> NSManagedObject {
+    @nonobjc public static func create(_ properties: [String: Any], context: NSManagedObjectContext) -> NSManagedObject {
         let newEntity: NSManagedObject = self.create(context: context)
         newEntity.update(properties)
         if let idprop = self.autoIncrementingId() {
-            if newEntity.primitiveValueForKey(idprop) == nil {
-                newEntity.setPrimitiveValue(NSNumber(integer: self.nextId()), forKey: idprop)
+            if newEntity.primitiveValue(forKey: idprop) == nil {
+                newEntity.setPrimitiveValue(NSNumber(value: self.nextId() as Int), forKey: idprop)
             }
         }
         return newEntity
@@ -309,24 +370,24 @@ public extension NSManagedObject {
     public static func nextId() -> Int {
         let key = "SwiftRecord-" + self.entityName() + "-ID"
         if let _ = self.autoIncrementingId() {
-            let id = NSUserDefaults.standardUserDefaults().integerForKey(key)
-            NSUserDefaults.standardUserDefaults().setInteger(id + 1, forKey: key)
+            let id = UserDefaults.standard.integer(forKey: key)
+            UserDefaults.standard.set(id + 1, forKey: key)
             return id
         }
         return 0
     }
     
-    public func update(properties: [String:AnyObject]) {
+    open func update(_ properties: [String: Any]) {
         if (properties.count == 0) {
             return
         }
         let context = self.managedObjectContext ?? NSManagedObjectContext.defaultContext
-        let transformed = self.dynamicType.transformProperties(properties, context: context)
+        let transformed = type(of: self).transformProperties(properties, context: context)
         //Finish
         for (key, value) in transformed {
-            self.willChangeValueForKey(key)
-            self.setSafeValue(value, forKey: key)
-            self.didChangeValueForKey(key)
+            self.willChangeValue(forKey: key)
+            self.setSafeValue(value as AnyObject?, forKey: key)
+            self.didChangeValue(forKey: key)
         }
     }
     
@@ -340,19 +401,19 @@ public extension NSManagedObject {
         }
     }
     
-    public func save() -> Bool {
+    open func save() -> Bool {
         return self.saveTheContext()
     }
-    
-    public func delete() {
-        self.managedObjectContext!.deleteObject(self)
+
+    open func delete() {
+        self.managedObjectContext!.delete(self)
     }
     
     public static func deleteAll() {
         self.deleteAll(NSManagedObjectContext.defaultContext)
     }
     
-    public static func deleteAll(context: NSManagedObjectContext) {
+    public static func deleteAll(_ context: NSManagedObjectContext) {
         for o in self.all(context: context) {
             o.delete()
         }
@@ -364,26 +425,26 @@ public extension NSManagedObject {
     
     public static func entityName() -> String {
         var name = NSStringFromClass(self)
-        if name.rangeOfString(".") != nil {
+        if name.range(of: ".") != nil {
             
             let comp = name.characters.split {$0 == "."}.map { String($0) }
             if comp.count > 1 {
                 name = comp.last!
             }
         }
-        if name.rangeOfString("_") != nil {
+        if name.range(of: "_") != nil {
             var comp = name.characters.split {$0 == "_"}.map { String($0) }
             var last: String = ""
             var remove = -1
-            for (i,s) in comp.reverse().enumerate() {
+            for (i,s) in comp.reversed().enumerated() {
                 if last == s {
                     remove = i
                 }
                 last = s
             }
             if remove > -1 {
-                comp.removeAtIndex(remove)
-                name = comp.joinWithSeparator("_")
+                comp.remove(at: remove)
+                name = comp.joined(separator: "_")
             }
         }
         return name
@@ -391,20 +452,20 @@ public extension NSManagedObject {
     
     //Private
     
-    private static func transformProperties(properties: [String:AnyObject], context: NSManagedObjectContext) -> [String:AnyObject]{
-        let entity = NSEntityDescription.entityForName(self.entityName(), inManagedObjectContext: context)!
+    fileprivate static func transformProperties(_ properties: [String: Any], context: NSManagedObjectContext) -> [String: Any]{
+        let entity = NSEntityDescription.entity(forEntityName: self.entityName(), in: context)!
         let attrs = entity.attributesByName
         let rels = entity.relationshipsByName
         
-        var transformed = [String:AnyObject]()
+        var transformed = [String: Any]()
         for (key, value) in properties {
             let localKey = self.keyForRemoteKey(key, context: context)
             if attrs[localKey] != nil {
                 transformed[localKey] = value
             } else if let rel = rels[localKey] {
                 if SwiftRecord.generateRelationships {
-                    if rel.toMany {
-                        if let array = value as? [[String:AnyObject]] {
+                    if rel.isToMany {
+                        if let array = value as? [[String: Any]] {
                             transformed[localKey] = self.generateSet(rel, array: array, context: context)
                         } else {
                             #if DEBUG
@@ -412,7 +473,7 @@ public extension NSManagedObject {
                                 print(value)
                             #endif
                         }
-                    } else if let dict = value as? [String:AnyObject] {
+                    } else if let dict = value as? [String: Any] {
                         transformed[localKey] = self.generateObject(rel, dict: dict, context: context)
                     } else {
                         #if DEBUG
@@ -426,50 +487,33 @@ public extension NSManagedObject {
         return transformed
     }
     
-    private static func predicate(properties: [String:AnyObject]) -> NSPredicate {
+    fileprivate static func predicate(_ properties: [String: Any]?) -> NSPredicate? {
+        guard let properties = properties else {
+            return nil
+        }
+
         var preds = [NSPredicate]()
         for (key, value) in properties {
             preds.append(NSPredicate(format: "%K = %@", argumentArray: [key, value]))
         }
-        return NSCompoundPredicate(type: NSCompoundPredicateType.AndPredicateType, subpredicates: preds)
+        return NSCompoundPredicate(type: NSCompoundPredicate.LogicalType.and, subpredicates: preds)
+    }
+
+    fileprivate static func predicate(_ condition: String?, args: [Any]? = nil) -> NSPredicate? {
+        guard let condition = condition else {
+            return nil
+        }
+
+        return NSPredicate(format: condition, argumentArray: args)
     }
     
-    private static func predicate(condition: AnyObject) -> NSPredicate {
-        return self.predicate(condition, args: nil)
-    }
-    
-    private static func predicate(condition: AnyObject, args: [AnyObject]?) -> NSPredicate {
-        if condition is NSPredicate {
-            return condition as! NSPredicate
-        }
-        if condition is String {
-            return NSPredicate(format: condition as! String, argumentArray: args)
-        }
-        if let d = condition as? [String:AnyObject] {
-            return self.predicate(d)
-        }
-        return NSPredicate()
-    }
-    
-    private static func sortDescriptor(o: AnyObject) -> NSSortDescriptor {
-        if let _ = o as? String {
-            return self.sortDescriptor(o)
-        }
-        if let d = o as? NSSortDescriptor {
-            return d
-        }
-        if let d = o as? [String:AnyObject] {
-            return self.sortDescriptor(d)
-        }
-        return NSSortDescriptor()
-    }
-    
-    private static func sortDescriptor(dict: [String:AnyObject]) -> NSSortDescriptor {
-        let isAscending = (dict.values.first as! String).uppercaseString != "DESC"
+    fileprivate static func sortDescriptor(_ dict: [String: Any]) -> NSSortDescriptor {
+        let isAscending = (dict.values.first as! String).uppercased() != "DESC"
         return NSSortDescriptor(key: dict.keys.first!, ascending: isAscending)
     }
     
-    private static func sortDescriptor(string: String) -> NSSortDescriptor {
+    fileprivate static func sortDescriptor(_ string: String) -> NSSortDescriptor {
+
         var key = string
         let components = string.characters.split {$0 == " "}.map { String($0) }
         var isAscending = true
@@ -480,20 +524,11 @@ public extension NSManagedObject {
         return NSSortDescriptor(key: key, ascending: isAscending)
     }
     
-    private static func sortDescriptors(d: AnyObject) -> [NSSortDescriptor] {
-        if let ds = d as? [NSSortDescriptor] {
-            return ds
+    fileprivate static func sortDescriptors(_ s: String?) -> [NSSortDescriptor]? {
+        guard let s = s else {
+            return nil
         }
-        if let s = d as? String {
-            return self.sortDescriptors(s)
-        }
-        if let dicts = d as? [[String:AnyObject]] {
-            return self.sortDescriptors(dicts)
-        }
-        return [self.sortDescriptor(d)]
-    }
-    
-    private static func sortDescriptors(s: String) -> [NSSortDescriptor]{
+
         let components = s.characters.split {$0 == ","}.map { String($0) }
         var ds = [NSSortDescriptor]()
         for sub in components {
@@ -502,11 +537,11 @@ public extension NSManagedObject {
         return ds
     }
     
-    private static func sortDescriptors(ds: [NSSortDescriptor]) -> [NSSortDescriptor] {
-        return ds
-    }
-    
-    private static func sortDescriptors(ds: [[String:AnyObject]]) -> [NSSortDescriptor] {
+    fileprivate static func sortDescriptors(_ ds: [[String: Any]]?) -> [NSSortDescriptor]? {
+        guard let ds = ds else {
+            return nil
+        }
+
         var ret = [NSSortDescriptor]()
         for d in ds {
             ret.append(self.sortDescriptor(d))
@@ -514,33 +549,167 @@ public extension NSManagedObject {
         return ret
     }
     
-    private static func createFetchRequest(context: NSManagedObjectContext) -> NSFetchRequest {
-        let request = NSFetchRequest()
-        request.entity = NSEntityDescription.entityForName(self.entityName(), inManagedObjectContext: context)
+    fileprivate static func createFetchRequest(_ context: NSManagedObjectContext) -> NSFetchRequest<NSFetchRequestResult> {
+        let request = NSFetchRequest<NSFetchRequestResult>()
+        request.entity = NSEntityDescription.entity(forEntityName: self.entityName(), in: context)
         return request
     }
     
-    private static func fetch(condition: AnyObject?, context: NSManagedObjectContext, sort: AnyObject?, limit: Int?) -> [NSManagedObject] {
+    fileprivate static func fetch(query: String?, context: NSManagedObjectContext, sortQuery: String?, limit: Int?, args: [Any]? = nil) -> [NSManagedObject] {
         let request = self.createFetchRequest(context)
-        
-        if let cond: AnyObject = condition {
-            request.predicate = self.predicate(cond)
-        }
-        
-        if let ord: AnyObject = sort {
-            request.sortDescriptors = self.sortDescriptors(ord)
-        }
+
+        request.predicate = self.predicate(query, args: args)
+        request.sortDescriptors = self.sortDescriptors(sortQuery)
         
         if let lim = limit {
             request.fetchLimit = lim
         }
 
+        return fetch(request: request, context: context)
+    }
+
+    fileprivate static func fetch(query: String?, context: NSManagedObjectContext, sortConditions: [[String: Any]]?, limit: Int?, args: [Any]? = nil) -> [NSManagedObject] {
+        let request = self.createFetchRequest(context)
+
+        request.predicate = self.predicate(query, args: args)
+        request.sortDescriptors = self.sortDescriptors(sortConditions)
+
+        if let lim = limit {
+            request.fetchLimit = lim
+        }
+
+        return fetch(request: request, context: context)
+    }
+
+    fileprivate static func fetch(query: String?, context: NSManagedObjectContext, sortCondition: [String: Any]?, limit: Int?, args: [Any]? = nil) -> [NSManagedObject] {
+        var conditions: [[String: Any]]?
+
+        if let condition = sortCondition {
+            conditions = [condition]
+        }
+
+        return fetch(query: query, context: context, sortConditions: conditions, limit: limit, args: args)
+    }
+
+
+    fileprivate static func fetch(query: String?, context: NSManagedObjectContext, sortDescriptors: [NSSortDescriptor]?, limit: Int?, args: [Any]? = nil) -> [NSManagedObject] {
+        let request = self.createFetchRequest(context)
+
+        request.predicate = self.predicate(query, args: args)
+        request.sortDescriptors = sortDescriptors
+
+        if let lim = limit {
+            request.fetchLimit = lim
+        }
+
+        return fetch(request: request, context: context)
+    }
+
+    fileprivate static func fetch(properties: [String: Any]?, context: NSManagedObjectContext, sortQuery: String?, limit: Int?) -> [NSManagedObject] {
+        let request = self.createFetchRequest(context)
+
+        request.predicate = self.predicate(properties)
+        request.sortDescriptors = self.sortDescriptors(sortQuery)
+
+        if let lim = limit {
+            request.fetchLimit = lim
+        }
+
+        return fetch(request: request, context: context)
+    }
+
+    fileprivate static func fetch(properties: [String: Any]?, context: NSManagedObjectContext, sortConditions: [[String: Any]]?, limit: Int?) -> [NSManagedObject] {
+        let request = self.createFetchRequest(context)
+
+        request.predicate = self.predicate(properties)
+        request.sortDescriptors = self.sortDescriptors(sortConditions)
+
+        if let lim = limit {
+            request.fetchLimit = lim
+        }
+
+        return fetch(request: request, context: context)
+    }
+
+    fileprivate static func fetch(properties: [String: Any]?, context: NSManagedObjectContext, sortCondition: [String: Any]?, limit: Int?) -> [NSManagedObject] {
+        var conditions: [[String: Any]]?
+
+        if let condition = sortCondition {
+            conditions = [condition]
+        }
+
+        return fetch(properties: properties, context: context, sortConditions: conditions, limit: limit)
+    }
+
+    fileprivate static func fetch(properties: [String: Any]?, context: NSManagedObjectContext, sortDescriptors: [NSSortDescriptor]?, limit: Int?) -> [NSManagedObject] {
+        let request = self.createFetchRequest(context)
+
+        request.predicate = self.predicate(properties)
+        request.sortDescriptors = sortDescriptors
+
+        if let lim = limit {
+            request.fetchLimit = lim
+        }
+
+        return fetch(request: request, context: context)
+    }
+
+    fileprivate static func fetch(predicate: NSPredicate?, context: NSManagedObjectContext, sortQuery: String?, limit: Int?) -> [NSManagedObject] {
+        let request = self.createFetchRequest(context)
+
+        request.predicate = predicate
+        request.sortDescriptors = self.sortDescriptors(sortQuery)
+
+        if let lim = limit {
+            request.fetchLimit = lim
+        }
+
+        return fetch(request: request, context: context)
+    }
+
+    fileprivate static func fetch(predicate: NSPredicate?, context: NSManagedObjectContext, sortConditions: [[String: Any]]?, limit: Int?) -> [NSManagedObject] {
+        let request = self.createFetchRequest(context)
+
+        request.predicate = predicate
+        request.sortDescriptors = self.sortDescriptors(sortConditions)
+
+        if let lim = limit {
+            request.fetchLimit = lim
+        }
+
+        return fetch(request: request, context: context)
+    }
+
+    fileprivate static func fetch(predicate: NSPredicate?, context: NSManagedObjectContext, sortCondition: [String: Any]?, limit: Int?) -> [NSManagedObject] {
+        var conditions: [[String: Any]]?
+
+        if let condition = sortCondition {
+            conditions = [condition]
+        }
+
+        return fetch(predicate: predicate, context: context, sortConditions: conditions, limit: limit)
+    }
+
+    fileprivate static func fetch(predicate: NSPredicate?, context: NSManagedObjectContext, sortDescriptors: [NSSortDescriptor]?, limit: Int?) -> [NSManagedObject] {
+        let request = self.createFetchRequest(context)
+
+        request.predicate = predicate
+        request.sortDescriptors = sortDescriptors
+
+        if let lim = limit {
+            request.fetchLimit = lim
+        }
+
+        return fetch(request: request, context: context)
+    }
+
+    fileprivate static func fetch(request: NSFetchRequest<NSFetchRequestResult>, context: NSManagedObjectContext) -> [NSManagedObject] {
         var result : [NSManagedObject]
-        
+
         do {
             var fetchResult : [AnyObject]
-            try fetchResult = context.executeFetchRequest(request)
-            
+            try fetchResult = context.fetch(request)
+
             if let fetchResultTyped = fetchResult as? [NSManagedObject] {
                 result = fetchResultTyped
             } else {
@@ -550,24 +719,24 @@ public extension NSManagedObject {
             print("Error executing fetch request \(request): " + error.description)
             result = [NSManagedObject]()
         }
-        
+
         return result
     }
     
-    private static func countForFetch(predicate: NSPredicate?, context: NSManagedObjectContext) -> Int {
+    fileprivate static func countForFetch(_ predicate: NSPredicate?, context: NSManagedObjectContext) -> Int {
         let request = self.createFetchRequest(context)
         request.predicate = predicate
         
-        return try! context.countForFetchRequest(request)
+        return try! context.count(for: request)
     }
     
-    private static func count(predicate: NSPredicate, context: NSManagedObjectContext) -> Int {
+    fileprivate static func count(_ predicate: NSPredicate, context: NSManagedObjectContext) -> Int {
         let request = self.createFetchRequest(context)
         request.predicate = predicate
-        return try! context.countForFetchRequest(request)
+        return try! context.count(for: request)
     }
     
-    private func saveTheContext() -> Bool {
+    fileprivate func saveTheContext() -> Bool {
         if self.managedObjectContext == nil || !self.managedObjectContext!.hasChanges {
             return true
         }
@@ -584,7 +753,7 @@ public extension NSManagedObject {
         return true
     }
     
-    private func setSafeValue(value: AnyObject?, forKey key: String) {
+    fileprivate func setSafeValue(_ value: AnyObject?, forKey key: String) {
         if (value == nil) {
             self.setNilValueForKey(key)
             return
@@ -592,20 +761,20 @@ public extension NSManagedObject {
         let val: AnyObject = value!
         if let attr = self.entity.attributesByName[key] {
             let attrType = attr.attributeType
-            if attrType == NSAttributeType.StringAttributeType && value is NSNumber {
+            if attrType == NSAttributeType.stringAttributeType && value is NSNumber {
                 self.setPrimitiveValue((val as! NSNumber).stringValue, forKey: key)
             } else if let s = val as? String {
                 if self.isIntegerAttributeType(attrType) {
-                    self.setPrimitiveValue(NSNumber(integer: val.integerValue), forKey: key)
+                    self.setPrimitiveValue(NSNumber(value: val.intValue as Int), forKey: key)
                     return
-                } else if attrType == NSAttributeType.BooleanAttributeType {
-                    self.setPrimitiveValue(NSNumber(bool: val.boolValue), forKey: key)
+                } else if attrType == NSAttributeType.booleanAttributeType {
+                    self.setPrimitiveValue(NSNumber(value: val.boolValue as Bool), forKey: key)
                     return
-                } else if (attrType == NSAttributeType.FloatAttributeType) {
+                } else if (attrType == NSAttributeType.floatAttributeType) {
                     self.setPrimitiveValue(NSNumber(floatLiteral: val.doubleValue), forKey: key)
                     return
-                } else if (attrType == NSAttributeType.DateAttributeType) {
-                    self.setPrimitiveValue(self.dynamicType.dateFormatter.dateFromString(s), forKey: key)
+                } else if (attrType == NSAttributeType.dateAttributeType) {
+                    self.setPrimitiveValue(type(of: self).dateFormatter.date(from: s), forKey: key)
                     return
                 }
             }
@@ -613,30 +782,30 @@ public extension NSManagedObject {
         self.setPrimitiveValue(value, forKey: key)
     }
     
-    private func isIntegerAttributeType(attrType: NSAttributeType) -> Bool {
-        return attrType == NSAttributeType.Integer16AttributeType || attrType == NSAttributeType.Integer32AttributeType || attrType == NSAttributeType.Integer64AttributeType
+    fileprivate func isIntegerAttributeType(_ attrType: NSAttributeType) -> Bool {
+        return attrType == NSAttributeType.integer16AttributeType || attrType == NSAttributeType.integer32AttributeType || attrType == NSAttributeType.integer64AttributeType
     }
     
-    private static var dateFormatter: NSDateFormatter {
+    fileprivate static var dateFormatter: DateFormatter {
         if _dateFormatter == nil {
-            _dateFormatter = NSDateFormatter()
+            _dateFormatter = DateFormatter()
             _dateFormatter!.dateFormat = "yyyy-MM-dd HH:mm:ss z"
         }
         return _dateFormatter!
     }
-    private static var _dateFormatter: NSDateFormatter?
+    fileprivate static var _dateFormatter: DateFormatter?
 }
 
-public extension NSManagedObject {
-    public class func mappings() -> [String:String] {
-        return [String:String]()
+extension NSManagedObject {
+    open class func mappings() -> [String: String] {
+        return [String: String]()
     }
     
-    public static func keyForRemoteKey(remote: String, context: NSManagedObjectContext) -> String {
+    public static func keyForRemoteKey(_ remote: String, context: NSManagedObjectContext) -> String {
         if let s = cachedMappings[remote] {
             return s
         }
-        let entity = NSEntityDescription.entityForName(self.entityName(), inManagedObjectContext: context)!
+        let entity = NSEntityDescription.entity(forEntityName: self.entityName(), in: context)!
         let properties = entity.propertiesByName
         if properties[remote] != nil {
             _cachedMappings![remote] = remote
@@ -651,7 +820,7 @@ public extension NSManagedObject {
         _cachedMappings![remote] = remote
         return remote
     }
-    private static var cachedMappings: [String:String] {
+    fileprivate static var cachedMappings: [String:String] {
         if let m = _cachedMappings {
             return m
         } else {
@@ -663,9 +832,9 @@ public extension NSManagedObject {
             return m
         }
     }
-    private static var _cachedMappings: [String:String]?
+    fileprivate static var _cachedMappings: [String: String]?
     
-    private static func generateSet(rel: NSRelationshipDescription, array: [[String:AnyObject]], context: NSManagedObjectContext) -> NSSet {
+    fileprivate static func generateSet(_ rel: NSRelationshipDescription, array: [[String: Any]], context: NSManagedObjectContext) -> NSSet {
         var cls: NSManagedObject.Type?
         if SwiftRecord.nameToEntities.count > 0 {
             cls = SwiftRecord.nameToEntities[rel.destinationEntity!.managedObjectClassName]
@@ -677,12 +846,12 @@ public extension NSManagedObject {
         }
         let set = NSMutableSet()
         for d in array {
-            set.addObject(cls!.findOrCreate(d, context: context))
+            set.add(cls!.findOrCreate(d, context: context))
         }
         return set
     }
     
-    private static func generateObject(rel: NSRelationshipDescription, dict: [String:AnyObject], context: NSManagedObjectContext) -> NSManagedObject {
+    fileprivate static func generateObject(_ rel: NSRelationshipDescription, dict: [String: Any], context: NSManagedObjectContext) -> NSManagedObject {
         let entity = rel.destinationEntity!
         
         let cls: NSManagedObject.Type = NSClassFromString(entity.managedObjectClassName) as! NSManagedObject.Type
@@ -690,27 +859,27 @@ public extension NSManagedObject {
     }
     
     public static func primaryKey() -> String {
-        NSException(name: "Primary key undefined in " + NSStringFromClass(self), reason: "Override primaryKey if you want to support automatic creation, otherwise disable this feature", userInfo: nil).raise()
+        assertionFailure("Primary key undefined in \(NSStringFromClass(self)). Override primaryKey if you want to support automatic creation, otherwise disable this feature")
         return ""
     }
 }
 
 private extension String {
     var camelCase: String {
-        let spaced = self.stringByReplacingOccurrencesOfString("_", withString: " ", options: [], range:Range<String.Index>(start: self.startIndex, end: self.endIndex))
-        let capitalized = spaced.capitalizedString
-        let spaceless = capitalized.stringByReplacingOccurrencesOfString(" ", withString: "", options:[], range:Range<String.Index>(start:self.startIndex, end:self.endIndex))
-        return spaceless.stringByReplacingCharactersInRange(Range<String.Index>(start:spaceless.startIndex, end:spaceless.startIndex.successor()), withString: "\(spaceless[spaceless.startIndex])".lowercaseString)
+        let spaced = self.replacingOccurrences(of: "_", with: " ")
+        let capitalized = spaced.capitalized
+        let spaceless = capitalized.replacingOccurrences(of: " ", with: "")
+        return spaceless.replacingCharacters(in: (spaceless.startIndex ..< spaceless.characters.index(after: spaceless.startIndex)), with: "\(spaceless[spaceless.startIndex])".lowercased())
     }
 }
 
 extension NSObject {
     // create a static method to get a swift class for a string name
-    class func swiftClassFromString(className: String) -> AnyClass! {
+    class func swiftClassFromString(_ className: String) -> AnyClass! {
         // get the project name
-        if  let appName: String? = NSBundle.mainBundle().objectForInfoDictionaryKey("CFBundleName") as? String {
+        if  let appName = Bundle.main.object(forInfoDictionaryKey: "CFBundleName") as? String {
             // generate the full name of your class (take a look into your "YourProject-swift.h" file)
-            let classStringName = "_TtC\(appName!.utf16.count)\(appName)\(className.characters.count)\(className)"
+            let classStringName = "_TtC\(appName.utf16.count)\(appName)\(className.characters.count)\(className)"
             // return the class!
             
             return NSClassFromString(classStringName)

--- a/SwiftRecord/SwiftRecord.xcodeproj/project.pbxproj
+++ b/SwiftRecord/SwiftRecord.xcodeproj/project.pbxproj
@@ -376,7 +376,7 @@
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = NO;
 				SUPPORTED_PLATFORMS = "iphonesimulator iphoneos macosx";
-				SWIFT_VERSION = 2.3;
+				SWIFT_VERSION = 3.0;
 				VALID_ARCHS = "arm64 armv7 armv7s x86_64 i386";
 			};
 			name = Debug;
@@ -396,7 +396,7 @@
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = NO;
 				SUPPORTED_PLATFORMS = "iphonesimulator iphoneos macosx";
-				SWIFT_VERSION = 2.3;
+				SWIFT_VERSION = 3.0;
 				VALID_ARCHS = "arm64 armv7 armv7s x86_64 i386";
 			};
 			name = Release;


### PR DESCRIPTION
Hey,

Needed to upgrade a project to Swift 3.0 which made use of SwiftRecord, so I took the opportunity to make the upgrade of SwiftRecord myself. I also took the chance to eliminate the abuse of AnyObject in the process,  creating proper overloads instead. Also introduced default values for some arguments since there would need to be a ton of more overloads without them :-)

I had to mark methods using overloading with `@nonobjc` since Objective-C doesn't support it. I also didn't want to make any API breaking changes, but it would probably be a good idea to eliminate the overloading as well in the future by introducing more fitting argument labels (and adding labels to first argument as we should in Swift 3.0). E.g:

`func query(_ condition: NSPredicate, context: NSManagedObjectContext = NSManagedObjectContext.defaultContext, limit: Int? = nil) -> [NSManagedObject])`

would become:

`func query(predicate: NSPredicate, context: NSManagedObjectContext = NSManagedObjectContext.defaultContext, limit: Int? = nil) -> [NSManagedObject])`

Hope everything looks OK!

Regards,
Johannes